### PR TITLE
allow all user to access large object

### DIFF
--- a/dev_setup/cookbooks/postgresql/metadata.rb
+++ b/dev_setup/cookbooks/postgresql/metadata.rb
@@ -1,3 +1,4 @@
+name             "postgresql"
 maintainer       "VMware"
 maintainer_email "support@vmware.com"
 license          "Apache 2.0"


### PR DESCRIPTION
http://www.postgresql.org/docs/9.3/interactive/runtime-config-compatible.html#RUNTIME-CONFIG-COMPATIBLE-CLIENTS

Setting this variable to on disables the new privilege checks, for compatibility with prior releases. The default is off. Only superusers can change this setting.